### PR TITLE
splitscreen

### DIFF
--- a/camera.py
+++ b/camera.py
@@ -26,7 +26,7 @@ class Camera:
             surface (pygame.Surface): Surface to draw on
 
         """
-        self.pos: Vec2 = pos
+        self.pos: Vec2 = Vec2(pos)
         self.zoom: float = zoom
         self.surface: pygame.Surface = surface
 

--- a/main.py
+++ b/main.py
@@ -131,7 +131,6 @@ while True:
         camera.draw_text("GAME OVER", None, font, Color("red"))
     else:
         universe.handle_input(pygame.key.get_pressed())
-
         universe.step(dt)
 
         if (

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from pygame import Color
 from pygame.math import Vector2 as Vec2
 
 from camera import Camera
-from ship import BulletEnemy, RocketEnemy, Ship
+from ship import BulletEnemy, RocketEnemy, ShipInput, PlayerShip
 from universe import Area, Asteroid, Planet, RefuelArea, TrophyArea, Universe
 
 # Initialize Pygame
@@ -71,8 +71,16 @@ else:
     ]
 
 
-player_ship = Ship(
-    SPAWNPOINT, Vec2(0, 0), 1, 10, Color("darkslategray"), Color("yellow")
+player_ship = PlayerShip(
+    SPAWNPOINT,
+    Vec2(0, 0),
+    1,
+    10,
+    Color("darkslategray"),
+    Color("yellow"),
+    ShipInput(
+        pygame.K_RIGHT, pygame.K_LEFT, pygame.K_UP, pygame.K_DOWN, pygame.K_SPACE
+    ),
 )
 
 
@@ -104,7 +112,7 @@ universe = Universe(
     WORLD_SIZE,
     planets,
     asteroids,
-    player_ship,
+    [player_ship],
     areas,
     enemy_ships,
 )
@@ -122,14 +130,7 @@ while True:
         font = pygame.font.Font(None, 64)
         camera.draw_text("GAME OVER", None, font, Color("red"))
     else:
-        # Handle input
-        keys = pygame.key.get_pressed()
-        player_ship.thruster_rot_left = keys[pygame.K_RIGHT]
-        player_ship.thruster_rot_right = keys[pygame.K_LEFT]
-        player_ship.thruster_forward = keys[pygame.K_UP]
-        player_ship.thruster_backward = keys[pygame.K_DOWN]
-        if keys[pygame.K_SPACE]:
-            player_ship.shoot()
+        universe.handle_input(pygame.key.get_pressed())
 
         universe.step(dt)
 

--- a/main.py
+++ b/main.py
@@ -73,23 +73,23 @@ else:
 
 player_ships = [
     PlayerShip(
-        SPAWNPOINT,
+        SPAWNPOINT + Vec2(800, 0),
         Vec2(0, 0),
         1,
         10,
-        Color("darkslategray"),
-        Color("yellow"),
+        Color("white"),
+        Color("orange"),
         ShipInput(
             pygame.K_RIGHT, pygame.K_LEFT, pygame.K_UP, pygame.K_DOWN, pygame.K_SPACE
         ),
     ),
     PlayerShip(
-        SPAWNPOINT + Vec2(30, 0),
+        SPAWNPOINT + Vec2(0, 0),
         Vec2(0, 0),
         1,
         10,
-        Color("white"),
-        Color("purple"),
+        Color("darkslategray"),
+        Color("yellow"),
         ShipInput(
             pygame.K_RIGHT, pygame.K_LEFT, pygame.K_UP, pygame.K_DOWN, pygame.K_SPACE
         ),

--- a/main.py
+++ b/main.py
@@ -71,17 +71,30 @@ else:
     ]
 
 
-player_ship = PlayerShip(
-    SPAWNPOINT,
-    Vec2(0, 0),
-    1,
-    10,
-    Color("darkslategray"),
-    Color("yellow"),
-    ShipInput(
-        pygame.K_RIGHT, pygame.K_LEFT, pygame.K_UP, pygame.K_DOWN, pygame.K_SPACE
+player_ships = [
+    PlayerShip(
+        SPAWNPOINT,
+        Vec2(0, 0),
+        1,
+        10,
+        Color("darkslategray"),
+        Color("yellow"),
+        ShipInput(
+            pygame.K_RIGHT, pygame.K_LEFT, pygame.K_UP, pygame.K_DOWN, pygame.K_SPACE
+        ),
     ),
-)
+    PlayerShip(
+        SPAWNPOINT + Vec2(30, 0),
+        Vec2(0, 0),
+        1,
+        10,
+        Color("white"),
+        Color("purple"),
+        ShipInput(
+            pygame.K_RIGHT, pygame.K_LEFT, pygame.K_UP, pygame.K_DOWN, pygame.K_SPACE
+        ),
+    ),
+]
 
 
 asteroids: list[Asteroid] = []
@@ -95,9 +108,9 @@ enemy_ships: list[BulletEnemy] = []
 for _ in range(50):
     pos = Vec2(random.uniform(0, WORLD_SIZE.x), random.uniform(0, WORLD_SIZE.y))
     if random.random() > 0.5:
-        enemy_ships.append(BulletEnemy(pos, Vec2(0, 0), player_ship))
+        enemy_ships.append(BulletEnemy(pos, Vec2(0, 0), random.choice(player_ships)))
     else:
-        enemy_ships.append(RocketEnemy(pos, Vec2(0, 0), player_ship))
+        enemy_ships.append(RocketEnemy(pos, Vec2(0, 0), random.choice(player_ships)))
 
 planets = [Planet(Vec2(6_000, 1_000), 1, 300, Color("darkred"), None)]
 
@@ -112,7 +125,7 @@ universe = Universe(
     WORLD_SIZE,
     planets,
     asteroids,
-    [player_ship],
+    player_ships,
     areas,
     enemy_ships,
 )
@@ -133,12 +146,13 @@ while True:
         universe.handle_input(pygame.key.get_pressed())
         universe.step(dt)
 
-        if (
-            not universe.contains_point(player_ship.pos) or player_ship.health <= 0
-        ) and not TEST_MODE:
-            game_over = True
+        for player_ship in player_ships:
+            if (
+                not universe.contains_point(player_ship.pos) or player_ship.health <= 0
+            ) and not TEST_MODE:
+                game_over = True
         camera.smoothly_focus_points(
-            [player_ship.pos, player_ship.pos + 1 * player_ship.vel],
+            [p.pos for p in player_ships] + [p.pos + 1.0 * p.vel for p in player_ships],
             500,
             dt,
         )

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from pygame import Color
 from pygame.math import Vector2 as Vec2
 
 from camera import Camera
-from ship import BulletEnemy, RocketEnemy, ShipInput, PlayerShip
+from ship import BulletEnemy, PlayerShip, RocketEnemy, ShipInput
 from universe import Area, Asteroid, Planet, RefuelArea, TrophyArea, Universe
 
 # Initialize Pygame

--- a/main.py
+++ b/main.py
@@ -73,14 +73,14 @@ else:
 
 player_ships = [
     PlayerShip(
-        SPAWNPOINT + Vec2(800, 0),
+        SPAWNPOINT + Vec2(100, 0),
         Vec2(0, 0),
         1,
         10,
         Color("white"),
         Color("orange"),
         ShipInput(
-            pygame.K_RIGHT, pygame.K_LEFT, pygame.K_UP, pygame.K_DOWN, pygame.K_SPACE
+            pygame.K_RIGHT, pygame.K_LEFT, pygame.K_UP, pygame.K_DOWN, pygame.K_RETURN
         ),
     ),
     PlayerShip(
@@ -90,9 +90,7 @@ player_ships = [
         10,
         Color("darkslategray"),
         Color("yellow"),
-        ShipInput(
-            pygame.K_LEFT, pygame.K_LEFT, pygame.K_UP, pygame.K_DOWN, pygame.K_SPACE
-        ),
+        ShipInput(pygame.K_d, pygame.K_a, pygame.K_w, pygame.K_s, pygame.K_SPACE),
     ),
 ]
 
@@ -158,10 +156,10 @@ while True:
             font = pygame.font.Font(None, int(64 / player_count))
             player_camera.draw_text("GAME OVER", None, font, Color("red"))
         else:
-            universe.move_camera(player_camera, dt)
+            universe.move_camera(player_camera, player_ix, dt)
             universe.draw_grid(player_camera)
             universe.draw(player_camera)
-            universe.draw_text(player_camera)
+            universe.draw_text(player_camera, player_ix)
 
     minimap_camera.start_drawing_new_frame()
     universe.draw(minimap_camera)

--- a/main.py
+++ b/main.py
@@ -151,12 +151,8 @@ while True:
                 not universe.contains_point(player_ship.pos) or player_ship.health <= 0
             ) and not TEST_MODE:
                 game_over = True
-        camera.smoothly_focus_points(
-            [p.pos for p in player_ships] + [p.pos + 1.0 * p.vel for p in player_ships],
-            500,
-            dt,
-        )
 
+        universe.move_camera(camera, dt)
         universe.draw_grid(camera)
         universe.draw(camera)
         universe.draw_text(camera)

--- a/physics.py
+++ b/physics.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 from pygame.math import Vector2 as Vec2
+from pygame import Color
 
 if TYPE_CHECKING:
-    from pygame import Color
-
     from camera import Camera
 
 GRAVITATIONAL_CONSTANT = 0.03
@@ -120,6 +119,7 @@ class Disk(PhysicalObject):
         super().__init__(pos, vel, mass)
         self.radius = radius
         self.color = Color(color)
+        # print(bullet_color, Color(bullet_color))
         self.bulletcolor = Color(bullet_color)
         self._radius_squared = radius**2
 

--- a/physics.py
+++ b/physics.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import math
 from typing import TYPE_CHECKING
+from pygame.math import Vector2 as Vec2
 
 if TYPE_CHECKING:
     from pygame import Color
-    from pygame.math import Vector2 as Vec2
 
     from camera import Camera
 
@@ -29,9 +29,9 @@ class PhysicalObject:
             mass (float): Object's mass
 
         """
-        self.pos = pos
+        self.pos = Vec2(pos)
         self.mass = mass
-        self.vel = vel
+        self.vel = Vec2(vel)
 
     def step(self, dt: float) -> None:
         """Apply its velocity to `self`.

--- a/physics.py
+++ b/physics.py
@@ -119,8 +119,8 @@ class Disk(PhysicalObject):
         mass = radius**3 * math.pi * 4 / 3 * density
         super().__init__(pos, vel, mass)
         self.radius = radius
-        self.color = color
-        self.bulletcolor = bullet_color
+        self.color = Color(color)
+        self.bulletcolor = Color(bullet_color)
         self._radius_squared = radius**2
 
     def draw(self, camera: Camera) -> None:

--- a/physics.py
+++ b/physics.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import math
 from typing import TYPE_CHECKING
-from pygame.math import Vector2 as Vec2
+
 from pygame import Color
+from pygame.math import Vector2 as Vec2
 
 if TYPE_CHECKING:
     from camera import Camera

--- a/projectiles.py
+++ b/projectiles.py
@@ -26,7 +26,7 @@ class Bullet(PhysicalObject):
 
         """
         super().__init__(pos, vel, 1.0)
-        self.color = color
+        self.color = Color(color)
 
     def draw(self, camera: Camera) -> None:
         """Draw `self` on `camera`.

--- a/ship.py
+++ b/ship.py
@@ -249,7 +249,7 @@ class Ship(Disk):
         for projectile in self.projectiles:
             projectile.draw(camera)
 
-class SpaceshipInput:
+class ShipInput:
     """Specification for which keys trigger what spaceship-action"""
 
     type pygame_key = int
@@ -291,7 +291,7 @@ class PlayerShip(Ship):
         size: float,
         color: Color,
         bullet_color: Color,
-        spaceship_input: SpaceshipInput,
+        spaceship_input: ShipInput,
     ) -> None:
         """Create a new player-spaceship.
 

--- a/ship.py
+++ b/ship.py
@@ -319,7 +319,6 @@ class PlayerShip(Ship):
             keys (pygame.key.ScancodeWrapper): Pressed keys
 
         """
-        print(keys[self.spaceship_input.thruster_rot_left])
         self.thruster_rot_left = keys[self.spaceship_input.thruster_rot_left]
         self.thruster_rot_right = keys[self.spaceship_input.thruster_rot_right]
         self.thruster_forward = keys[self.spaceship_input.thruster_forward]

--- a/ship.py
+++ b/ship.py
@@ -58,7 +58,7 @@ class Ship(Disk):
         self.projectiles: list[Bullet] = []
         self.gun_cooldown: float = 0
         self.has_trophy: bool = False
-        self.bullet_color = bullet_color
+        self.bullet_color = Color(bullet_color)
 
         self.ammo: int = 600
         self.thrust: float = 250 * self.mass

--- a/ship.py
+++ b/ship.py
@@ -253,15 +253,15 @@ class Ship(Disk):
 class ShipInput:
     """Specification for which keys trigger what spaceship-action."""
 
-    type pygame_key = int
+    type PygameKey = int
 
     def __init__(
         self,
-        thruster_rot_left: pygame_key,
-        thruster_rot_right: pygame_key,
-        thruster_forward: pygame_key,
-        thruster_backward: pygame_key,
-        shoot: pygame_key,
+        thruster_rot_left: PygameKey,
+        thruster_rot_right: PygameKey,
+        thruster_forward: PygameKey,
+        thruster_backward: PygameKey,
+        shoot: PygameKey,
     ) -> None:
         """Create a new map from keys to spaceship-actions.
 

--- a/ship.py
+++ b/ship.py
@@ -319,21 +319,13 @@ class PlayerShip(Ship):
             keys (pygame.key.ScancodeWrapper): Pressed keys
 
         """
+        print(keys[self.spaceship_input.thruster_rot_left])
         self.thruster_rot_left = keys[self.spaceship_input.thruster_rot_left]
         self.thruster_rot_right = keys[self.spaceship_input.thruster_rot_right]
         self.thruster_forward = keys[self.spaceship_input.thruster_forward]
         self.thruster_backward = keys[self.spaceship_input.thruster_backward]
         if keys[self.spaceship_input.shoot]:
             self.shoot()
-
-    def step(self, dt: float) -> None:
-        """Physics, control, and bullet-stepping for `self`.
-
-        Args:
-        ----
-            dt (float): Passed time
-
-        """
 
 class BulletEnemy(Ship):
     """An enemy ship, targeting a specific other ship."""

--- a/ship.py
+++ b/ship.py
@@ -8,6 +8,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 from pygame import Color
+import pygame
 from pygame.math import Vector2 as Vec2
 
 from physics import Disk
@@ -248,6 +249,91 @@ class Ship(Disk):
         for projectile in self.projectiles:
             projectile.draw(camera)
 
+class SpaceshipInput:
+    """Specification for which keys trigger what spaceship-action"""
+
+    type pygame_key = int
+
+    def __init__(
+        self,
+        thruster_rot_left: pygame_key,
+        thruster_rot_right: pygame_key,
+        thruster_forward: pygame_key,
+        thruster_backward: pygame_key,
+        shoot: pygame_key,
+    ):
+        """Create a new map from keys to spaceship-actions
+
+        Args:
+        ----
+            thruster_rot_left (pygame_key): Left rotation thruster's key
+            thruster_rot_right (pygame_key): Right rotation thruster's key
+            thruster_forward (pygame_key): Forward thruster's key
+            thruster_backward (pygame_key): Backward thruster's key
+            shoot (pygame_key): Pew pew key
+
+        """
+        self.thruster_rot_left = thruster_rot_left
+        self.thruster_rot_right = thruster_rot_right
+        self.thruster_forward = thruster_forward
+        self.thruster_backward = thruster_backward
+        self.shoot = shoot
+
+
+class PlayerShip(Ship):
+    """A player-controlled spaceship."""
+
+    def __init__(
+        self,
+        pos: Vec2,
+        vel: Vec2,
+        density: float,
+        size: float,
+        color: Color,
+        bullet_color: Color,
+        spaceship_input: SpaceshipInput,
+    ) -> None:
+        """Create a new player-spaceship.
+
+        Args:
+        ----
+            pos (Vec2): Initial position
+            vel (Vec2): Initial velocity
+            density (float): Density (of disk-body)
+            size (float): Radius of disk-body
+            color (Color): Material color
+            bullet_color (Color): Bullet_color
+            spaceship_input (SpaceshipInput): Map from keys to actions
+
+        """
+        super().__init__(pos, vel, density, size, color, bullet_color)
+        self.spaceship_input = spaceship_input
+
+    def handle_input(self, keys: pygame.key.ScancodeWrapper):
+        """Handle input for `self` using ScancodeWrapper `keys`.
+
+        `keys` is typically retreived using `pygame.key.get_pressed()`
+
+        Args:
+        ----
+            keys (pygame.key.ScancodeWrapper): Pressed keys
+
+        """
+        self.thruster_rot_left = keys[self.spaceship_input.thruster_rot_left]
+        self.thruster_rot_right = keys[self.spaceship_input.thruster_rot_right]
+        self.thruster_forward = keys[self.spaceship_input.thruster_forward]
+        self.thruster_backward = keys[self.spaceship_input.thruster_backward]
+        if keys[self.spaceship_input.shoot]:
+            self.shoot()
+
+    def step(self, dt: float) -> None:
+        """Physics, control, and bullet-stepping for `self`.
+
+        Args:
+        ----
+            dt (float): Passed time
+
+        """
 
 class BulletEnemy(Ship):
     """An enemy ship, targeting a specific other ship."""

--- a/ship.py
+++ b/ship.py
@@ -7,8 +7,8 @@ import random
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from pygame import Color
 import pygame
+from pygame import Color
 from pygame.math import Vector2 as Vec2
 
 from physics import Disk
@@ -249,8 +249,9 @@ class Ship(Disk):
         for projectile in self.projectiles:
             projectile.draw(camera)
 
+
 class ShipInput:
-    """Specification for which keys trigger what spaceship-action"""
+    """Specification for which keys trigger what spaceship-action."""
 
     type pygame_key = int
 
@@ -261,8 +262,8 @@ class ShipInput:
         thruster_forward: pygame_key,
         thruster_backward: pygame_key,
         shoot: pygame_key,
-    ):
-        """Create a new map from keys to spaceship-actions
+    ) -> None:
+        """Create a new map from keys to spaceship-actions.
 
         Args:
         ----
@@ -309,7 +310,7 @@ class PlayerShip(Ship):
         super().__init__(pos, vel, density, size, color, bullet_color)
         self.spaceship_input = spaceship_input
 
-    def handle_input(self, keys: pygame.key.ScancodeWrapper):
+    def handle_input(self, keys: pygame.key.ScancodeWrapper) -> None:
         """Handle input for `self` using ScancodeWrapper `keys`.
 
         `keys` is typically retreived using `pygame.key.get_pressed()`
@@ -325,6 +326,7 @@ class PlayerShip(Ship):
         self.thruster_backward = keys[self.spaceship_input.thruster_backward]
         if keys[self.spaceship_input.shoot]:
             self.shoot()
+
 
 class BulletEnemy(Ship):
     """An enemy ship, targeting a specific other ship."""

--- a/universe.py
+++ b/universe.py
@@ -293,6 +293,16 @@ class Universe:
                         enemy_ship.projectiles.remove(projectile)
                         break
 
+    def handle_input(self, keys: pygame.key.ScancodeWrapper) -> None:
+        """Run input-logic for player-ships.
+
+        Args:
+        ----
+            keys (pygame.key.ScancodeWrapper): Pressed keys
+        """
+        for player_ship in self.player_ships:
+            player_ship.handle_input(keys)
+
     def step(self, dt: float) -> None:
         """Run the universe-logic, also for the object `self` contains.
 

--- a/universe.py
+++ b/universe.py
@@ -181,7 +181,7 @@ class Universe:
             size (Vec2): Width and height
             planets (list[Planet]): Planets
             asteroids (list[Asteroid]): Asteroids
-            player_ship (Ship): Player's ship
+            player_ships (list[Ship]): List of player-ships
             areas (list[Area]): Areas
             enemy_ships (list[BulletEnemy]): Enemy fleet
 

--- a/universe.py
+++ b/universe.py
@@ -299,9 +299,27 @@ class Universe:
         Args:
         ----
             keys (pygame.key.ScancodeWrapper): Pressed keys
+
         """
         for player_ship in self.player_ships:
             player_ship.handle_input(keys)
+
+    def move_camera(self, camera: Camera, dt: float) -> None:
+        """Move the camera to `self.player_ships`.
+
+        Args:
+        ----
+            camera (Camera): Camera to move
+            dt (float): Passed time
+
+        """
+
+        camera.smoothly_focus_points(
+            [p.pos for p in self.player_ships]
+            + [p.pos + 1.0 * p.vel for p in self.player_ships],
+            500,
+            dt,
+        )
 
     def step(self, dt: float) -> None:
         """Run the universe-logic, also for the object `self` contains.

--- a/universe.py
+++ b/universe.py
@@ -304,19 +304,19 @@ class Universe:
         for player_ship in self.player_ships:
             player_ship.handle_input(keys)
 
-    def move_camera(self, camera: Camera, dt: float) -> None:
-        """Move the camera to `self.player_ships`.
+    def move_camera(self, camera: Camera, player_ix: int, dt: float) -> None:
+        """Move the camera to `self.player_ships[player_ix]`.
 
         Args:
         ----
             camera (Camera): Camera to move
+            player_ix (int): Player to focus on
             dt (float): Passed time
 
         """
-
+        ship = self.player_ships[player_ix]
         camera.smoothly_focus_points(
-            [p.pos for p in self.player_ships]
-            + [p.pos + 1.0 * p.vel for p in self.player_ships],
+            [ship.pos, ship.pos + 1.0 * ship.vel],
             500,
             dt,
         )
@@ -364,12 +364,13 @@ class Universe:
         ):
             pobj.draw(camera)
 
-    def draw_text(self, camera: Camera) -> None:
-        """Draw "debugging" text about `self` on `camera`.
+    def draw_text(self, camera: Camera, player_ix: int) -> None:
+        """Draw "debugging" text on `camera`.
 
         Args:
         ----
             camera (Camera): Camera to draw on
+            player_ix (int): Player to display information about
 
         """
         font_size = 32
@@ -384,17 +385,13 @@ class Universe:
                 )
             self.text_vertical_offset += 1.0 * font_size
 
-        for ix, player_ship in enumerate(self.player_ships):
-            texty(f"{ix} ({int(player_ship.pos.x)}, {int(player_ship.pos.y)})")
-            texty(
-                f"{ix} Velocity: ({int(player_ship.vel.x)}, {int(player_ship.vel.y)})"
-            )
-            texty(f"{ix} Remaining Fuel: {player_ship.fuel:.2f}")
-            texty(
-                f"{ix} Trophy: {"Collected" if player_ship.has_trophy else "Not collected"}"
-            )
-            texty(f"{ix} Health: {player_ship.health:.2f}")
-            texty(f"{ix} Ammunition: {player_ship.ammo}")
+        player_ship = self.player_ships[player_ix]
+        texty(f"({int(player_ship.pos.x)}, {int(player_ship.pos.y)})")
+        texty(f"Velocity: ({int(player_ship.vel.x)}, {int(player_ship.vel.y)})")
+        texty(f"Remaining Fuel: {player_ship.fuel:.2f}")
+        texty(f"Trophy: {"Collected" if player_ship.has_trophy else "Not collected"}")
+        texty(f"Health: {player_ship.health:.2f}")
+        texty(f"Ammunition: {player_ship.ammo}")
         for area in self.areas:
             texty(f"  Coordinates of {area.caption}: ({area.centerx}, {area.centery})")
         player_projectile_count = sum(len(p.projectiles) for p in self.player_ships)

--- a/universe.py
+++ b/universe.py
@@ -186,7 +186,7 @@ class Universe:
             enemy_ships (list[BulletEnemy]): Enemy fleet
 
         """
-        self.size = size
+        self.size = Vec2(size)
         self.planets = planets
         self.asteroids = asteroids
         self.player_ships = player_ships


### PR DESCRIPTION
- The `PlayerShip` is now a separate class, inheriting from `Ship`. It takes a new argument `spaceship_input` which specifies which keyboard-keys run what action for the ship.
- Input handling is now no longer done explicitly in the main-loop, but deferred to `Universe`.
- `Universe` now takes multiple player-ships.
- Depending on how many player-ship the universe has, it now implements splitscreen. The screen is divided into vertical bands for that. For a high number of players, this looks *exactly* as awful as you'd expect.

    ![image](https://github.com/user-attachments/assets/994b0773-1b5d-4fee-ac3e-87ac739b57d5)

The current code has two players, one controlled with WASD/SPACE, the other one with arrow-keys/ENTER. Just remove one of the players from the `player_ships` array in `main.py` to go back to singleplayer :)