### PR TITLE
Move from pygame to pygame-ce

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pygame==2.6.0
+pygame-ce==2.5.3


### PR DESCRIPTION
We currently use `pygame`, but `pygame-ce` (ce=="community edition") seems to be a more actively-maintained fork. More importantly for us, to quote the [pygbag](https://github.com/pygame-web/pygbag/blob/e31888a3a01a24d38e1bcb440eb0927a4f554d92/README.md?plain=1#L135) documentation:

> pygbag only provides support for pygame-ce ( pygame community edition )

If you decide to merge this change, you should `pip uninstall pygame` and then `pip install -r requirements.txt`.