### PR TITLE
Profiling

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ async def main() -> None:
     pygame.display.init()
     pygame.font.init()
     font = pygame.font.Font(None, 36)
-    options: Options = {"small": False, "splitscreen": False, "invincible": False, "profiling": False}
+    options: Options = {"small": False, "splitscreen": False, "invincible": False}
 
     try:
         pygame.display.set_caption("Space Game")

--- a/main.py
+++ b/main.py
@@ -189,13 +189,13 @@ async def main() -> None:
                     not universe.contains_point(player_ship.pos) or player_ship.health <= 0
                 ) and not options["invincible"]
                 if gameover:
-                    profiler.start("gameover")
                     gameover_font = pygame.font.Font(None, int(64 / player_count))
                     player_camera.draw_text("GAME OVER", None, gameover_font, Color("red"))
                     topleft = (int(player_ix * SCREEN_SIZE[0] / player_count), 0)
                     screen_surface.blit(player_camera.surface, topleft)
-                    await asyncio.sleep(5)  # Show "GAME OVER" for 5 seconds
-                    options = await show_menu(screen_surface, options, font)
+                    # TODO: Deal with remainder of issue #35
+                    # await asyncio.sleep(5)  # Show "GAME OVER" for 5 seconds
+                    # options = await show_menu(screen_surface, options, font)
                     break
                 profiler.start("universe.move_camera")
                 universe.move_camera(player_camera, player_ix, dt)

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import platform
 import random
 import sys
 from collections import deque
@@ -188,6 +189,7 @@ async def main() -> None:
                     not universe.contains_point(player_ship.pos) or player_ship.health <= 0
                 ) and not options["invincible"]
                 if gameover:
+                    profiler.start("gameover")
                     gameover_font = pygame.font.Font(None, int(64 / player_count))
                     player_camera.draw_text("GAME OVER", None, gameover_font, Color("red"))
                     topleft = (int(player_ix * SCREEN_SIZE[0] / player_count), 0)
@@ -239,6 +241,9 @@ async def main() -> None:
         raise
     finally:
         print(profiler.log())
+        if sys.platform == "emscripten":
+            platform.console.log("logged message")
+
         pygame.quit()
         sys.exit()
 

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from constants import (
     PLANET_RADIUS_SIGMA,
     SCREEN_SIZE,
 )
+from profiler import Profiler
 from ship import BulletEnemy, MissileEnemy, PlayerShip, RocketEnemy, ShipInput
 from universe import Planet, Universe
 
@@ -161,8 +162,10 @@ async def main() -> None:
         clock = pygame.time.Clock()
 
         fps: deque[float] = deque()
+        profiler = Profiler()
 
         while True:
+            profiler.start("other")
             if any(e.type == pygame.QUIT for e in pygame.event.get()):
                 break
 
@@ -172,12 +175,15 @@ async def main() -> None:
                 fps.popleft()
 
             universe.handle_input(pygame.key.get_pressed())
+            profiler.start("universe.step")
             universe.step(dt)
 
             # Draw each camera's view and then blit it into SCREEN_SURFACE
             for player_ix, player_ship in enumerate(player_ships):
                 player_camera = cameras[player_ix]
+                profiler.start("player_camera.start_drawing_new_frame")
                 player_camera.start_drawing_new_frame()
+                profiler.start("gameover_check")
                 gameover = (
                     not universe.contains_point(player_ship.pos) or player_ship.health <= 0
                 ) and not options["invincible"]
@@ -189,14 +195,21 @@ async def main() -> None:
                     await asyncio.sleep(5)  # Show "GAME OVER" for 5 seconds
                     options = await show_menu(screen_surface, options, font)
                     break
+                profiler.start("universe.move_camera")
                 universe.move_camera(player_camera, player_ix, dt)
+                profiler.start("universe.draw_background")
                 universe.draw_background(player_camera)
+                profiler.start("universe.draw_grid")
                 universe.draw_grid(player_camera)
+                profiler.start("universe.draw(player_camera)")
                 universe.draw(player_camera)
+                profiler.start("universe.draw_text")
                 universe.draw_text(player_camera, player_ix, sum(fps) / len(fps))
                 topleft = (int(player_ix * SCREEN_SIZE[0] / player_count), 0)
+                profiler.start("screen_surface.blit(player_camera.surface)")
                 screen_surface.blit(player_camera.surface, topleft)
 
+            profiler.start("minimap")
             minimap_camera.start_drawing_new_frame()
             universe.draw(minimap_camera)
             screen_surface.blit(minimap_camera.surface, (SCREEN_SIZE[0] - MINIMAP_SIZE.x, 0))
@@ -209,7 +222,10 @@ async def main() -> None:
                 universe.size.x,
                 universe.size.y - 1,
             )
+
+            profiler.start("pygame.display.flip()")
             pygame.display.flip()
+            profiler.start("asyncio.sleep(0)")
             await asyncio.sleep(0)
 
     except Exception as e:
@@ -222,6 +238,7 @@ async def main() -> None:
             await asyncio.sleep(5)
         raise
     finally:
+        print(profiler.log())
         pygame.quit()
         sys.exit()
 

--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ async def main() -> None:
     pygame.display.init()
     pygame.font.init()
     font = pygame.font.Font(None, 36)
-    options: Options = {"small": False, "splitscreen": False, "invincible": False}
+    options: Options = {"small": False, "splitscreen": False, "invincible": False, "profiling": False}
 
     try:
         pygame.display.set_caption("Space Game")

--- a/main.py
+++ b/main.py
@@ -164,10 +164,12 @@ async def main() -> None:
 
         fps: deque[float] = deque()
         profiler = Profiler()
+        running = True
 
-        while True:
+        while running:
             profiler.start("other")
             if any(e.type == pygame.QUIT for e in pygame.event.get()):
+                running = False
                 break
 
             dt = clock.tick() / 1_000
@@ -196,6 +198,7 @@ async def main() -> None:
                     # TODO: Deal with remainder of issue #35
                     # await asyncio.sleep(5)  # Show "GAME OVER" for 5 seconds
                     # options = await show_menu(screen_surface, options, font)
+                    running = False
                     break
                 profiler.start("universe.move_camera")
                 universe.move_camera(player_camera, player_ix, dt)
@@ -240,9 +243,10 @@ async def main() -> None:
             await asyncio.sleep(5)
         raise
     finally:
-        print(profiler.log())
+        profiler_stats = profiler.log()
+        print(profiler_stats)
         if sys.platform == "emscripten":
-            platform.console.log("logged message")
+            platform.console.log(profiler_stats)
 
         pygame.quit()
         sys.exit()

--- a/profiler.py
+++ b/profiler.py
@@ -28,7 +28,7 @@ class Profiler:
         """Show the current state of the profiler."""
         total_time = sum(self.times[name] for name in self.times)
         outputs: list[str] = []
-            outputs.append(f"{name}: {t / total_time * 100:.2f}%")
         for name, t in sorted(self.times.items(), key=lambda entry: entry[1]):
+            outputs.append(f"{t / total_time * 100:.2f}% {name}")
 
         return "\n".join(outputs)

--- a/profiler.py
+++ b/profiler.py
@@ -28,7 +28,7 @@ class Profiler:
         """Show the current state of the profiler."""
         total_time = sum(self.times[name] for name in self.times)
         outputs: list[str] = []
-        for name, t in sorted(self.times.items(), key=lambda entry: entry[0]):
             outputs.append(f"{name}: {t / total_time * 100:.2f}%")
+        for name, t in sorted(self.times.items(), key=lambda entry: entry[1]):
 
         return "\n".join(outputs)

--- a/profiler.py
+++ b/profiler.py
@@ -1,0 +1,34 @@
+"""A simple profiler."""
+
+import time
+
+
+class Profiler:
+    """A simple profiler."""
+
+    def __init__(self) -> None:
+        """Start the profiler."""
+        self.most_recent_time = time.time()
+        self.times: dict[str, float] = {}
+
+    def start(self, name: str) -> None:
+        """Start timing `name`.
+
+        The stopping-time is implicitly the time of the next start-call to `self`, with any name.
+        """
+        now = time.time()
+        delta = now - self.most_recent_time
+        if name in self.times:
+            self.times[name] = self.times[name] + delta
+        else:
+            self.times[name] = delta
+        self.most_recent_time = now
+
+    def log(self) -> str:
+        """Show the current state of the profiler."""
+        total_time = sum(self.times[name] for name in self.times)
+        outputs: list[str] = []
+        for name, t in sorted(self.times.items(), key=lambda entry: entry[0]):
+            outputs.append(f"{name}: {t / total_time * 100:.2f}%")
+
+        return "\n".join(outputs)

--- a/profiler.py
+++ b/profiler.py
@@ -29,6 +29,6 @@ class Profiler:
         total_time = sum(self.times[name] for name in self.times)
         outputs: list[str] = []
         for name, t in sorted(self.times.items(), key=lambda entry: entry[1]):
-            outputs.append(f"{t / total_time * 100:.2f}% {name}")
+            outputs.append(f"{t / total_time * 100:2f}% {name}")
 
         return "\n".join(outputs)


### PR DESCRIPTION
This adds a primitive profiler, as discussed in https://github.com/Tim2othy/spacegame/issues/49#issuecomment-2653460812

The profiler outputs to the console after the main-loop terminates, e.g. after a game-over or after quitting the program. If running in web, it outputs both to the python-console (visible in <localhost:8000/#debug>), and to the native browser-console.

Tentative results:
```
0.02% universe.move_camera
0.03% universe.draw_background
0.06% universe.step
0.51% minimap
0.61% universe.draw(player_camera)
1.06% other
1.14% gameover_check
4.07% universe.draw_text
4.53% asyncio.sleep(0)
4.71% pygame.display.flip()
5.04% screen_surface.blit(player_camera.surface)
14.39% player_camera.start_drawing_new_frame
63.84% universe.draw_grid
```
Looks like [*someone* 👀](https://github.com/Tim2othy/spacegame/commit/27b8323b98bb72b04a08f09d52c3f530a0951907) wrote inefficient gridline-code, which are rendered over *the whole universe*, even if they're off-screen. I'll repent and fix that soon.