### PR TITLE
9 better asteroid bouncing

### DIFF
--- a/physics.py
+++ b/physics.py
@@ -252,13 +252,14 @@ class Disk(PhysicalObject):
         # Position correction: push the disks apart so that they are just touching.
         # Respect the relative mass.
         overlap = radii_sum - distance
-        correction = normal * overlap / (self.mass + disk.mass)
-        self.pos -= correction * disk.mass
-        disk.pos += correction * self.mass
+        correction = normal * overlap
+        if math.isfinite(self.mass):
+            self.pos -= correction * (1 - self.mass / (self.mass + disk.mass))
+        if math.isfinite(disk.mass):
+            disk.pos += correction * (1 - disk.mass / (self.mass + disk.mass))
 
         # Compute damage. Here we simply use the magnitude of the impulse.
-        damage = abs(impulse_scalar)
-        return damage
+        return abs(impulse_scalar)
 
     def bounce_off_of_disk(self, disk: Disk) -> float | None:
         """Bounce self disks off of `disk` if they are overlapping.
@@ -281,8 +282,8 @@ class Disk(PhysicalObject):
             float | None: If float, impact velocity of bounce. None if no bounce occurred.
 
         """
-        old_mass = disk.mass
-        disk.mass = float_info.max  # This is a HACK
+        # HACK: Treat the static disk as if it had infinite mass
+        old_mass, disk.mass = disk.mass, float("inf")
         bounce = self.bounce_disks(disk)
         disk.mass = old_mass
         return bounce

--- a/physics.py
+++ b/physics.py
@@ -258,8 +258,8 @@ class Disk(PhysicalObject):
         if math.isfinite(disk.mass):
             disk.pos += correction * (1 - disk.mass / (self.mass + disk.mass))
 
-        # Compute damage. Here we simply use the magnitude of the impulse.
-        return abs(impulse_scalar)
+        # Return damage
+        return max(0, impulse_scalar - BOUNCE_DAMAGE_THRESHOLD) * (1 - BOUNCINESS) * BOUNCE_DAMAGE_SCALAR
 
     def bounce_off_of_disk(self, disk: Disk) -> float | None:
         """Bounce self disks off of `disk` if they are overlapping.

--- a/physics.py
+++ b/physics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from sys import float_info
 from typing import TYPE_CHECKING
 
 from pygame import Color
@@ -197,49 +198,91 @@ class Disk(PhysicalObject):
         """
         return self.pos.distance_squared_to(disk.pos) < (self.radius + disk.radius) ** 2
 
-    def bounce_off_of_disk(self, disk: Disk) -> float | None:
-        """Bounce `self` off of `disk`, iff the two intersect.
+    def bounce_disks(self, disk: Disk) -> float | None:
+        """Bounce two disks off each other if they are overlapping.
 
-        If a bounce occurs, this changes `self.pos` so that it's flush with `disk`,
-        and has velocity in the opposite direction.
+        If a bounce occurs, this shifts the two disks' positions so that
+        they're exactly flush. This shift respects the difference between
+        the two disks' mass.
 
-        Calculates intensity that `self` moved towards `disk` at moment of collision and
-        returns calculated impact-damage.
+        Returns the damage the two disks take from the collision.
+        The damage is identical for both disks, i.e. it assumes a heavier disk
+        can take more damage.
 
         If the two disks have exactly the same center, they are treated as if they
         were slightly offset from each other, with no guarantee about this behavior's
         stability.
 
-        Args:
-        ----
-            disk (Disk): Disk to potentially bounce off of
+        Parameters
+        ----------
+            disk (Disk): The other disk to try bouncing off of.
 
-        Returns:
+        Returns
         -------
-            float | None: If float, it's `self`'s suffered damage.
-                If None, the two didn't intersect.
+            float | None: If float, impact velocity of bounce. None if no bounce occurred.
 
         """
-        if not self.intersects_disk(disk):
+        delta = disk.pos - self.pos
+        radii_sum = self.radius + disk.radius
+        distance_squared = delta.magnitude_squared()
+
+        # Check for intersection
+        if distance_squared >= radii_sum**2:
             return None
 
-        # Calculate normal vector
-        delta = self.pos - disk.pos
-        if delta == Vec2(0, 0):
-            delta = Vec2(EPSILON, EPSILON)
-        delta_magnitude = delta.magnitude()
-        delta_normalized = delta / delta_magnitude
+        # Compute the distance; if 0 (disks on top of each other) choose an arbitrary normal.
+        distance = math.sqrt(distance_squared)
+        normal = delta / distance if distance_squared > 0 else Vec2(1, 0)
 
-        # Move self outside other
-        overlap = self.radius + disk.radius - delta_magnitude
-        self.pos += delta_normalized * overlap
+        relative_velocity = disk.vel - self.vel
+        vel_along_normal = relative_velocity.dot(normal)
 
-        self_vel_along_normal = self.vel.dot(delta_normalized)
-        impulse_scalar = -(1 + BOUNCINESS) * self_vel_along_normal
+        # If the disks are moving apart already, skip the collision response.
+        if vel_along_normal > 0:
+            return None
+
+        # Compute impulse scalar based on the collision response formula.
+        impulse_scalar = -(1 + BOUNCINESS) * vel_along_normal
         impulse_scalar /= 1 / self.mass + 1 / disk.mass
+        impulse = impulse_scalar * normal
 
-        self.add_impulse(delta_normalized * impulse_scalar)
+        self.add_impulse(-impulse)
+        disk.add_impulse(impulse)
 
-        # Return damage.
-        # Clamping in case of small impulses allows the ship to land on the planet.
-        return max(0, impulse_scalar - BOUNCE_DAMAGE_THRESHOLD) * (1 - BOUNCINESS) * BOUNCE_DAMAGE_SCALAR
+        # Position correction: push the disks apart so that they are just touching.
+        # Respect the relative mass.
+        overlap = radii_sum - distance
+        correction = normal * overlap / (self.mass + disk.mass)
+        self.pos -= correction * disk.mass
+        disk.pos += correction * self.mass
+
+        # Compute damage. Here we simply use the magnitude of the impulse.
+        damage = abs(impulse_scalar)
+        return damage
+
+    def bounce_off_of_disk(self, disk: Disk) -> float | None:
+        """Bounce self disks off of `disk` if they are overlapping.
+
+        If a bounce occurs, this shifts self's positions so that
+        they're exactly flush.
+
+        Returns the damage self takes from the collision.
+
+        If the two disks have exactly the same center, they are treated as if they
+        were slightly offset from each other, with no guarantee about this behavior's
+        stability.
+
+        Parameters
+        ----------
+            disk (Disk): The other disk to try bouncing off of.
+
+        Returns
+        -------
+            float | None: If float, impact velocity of bounce. None if no bounce occurred.
+
+        """
+        old_mass = disk.mass
+        disk.mass = float_info.max  # This is a HACK
+        bounce = self.bounce_disks(disk)
+        disk.mass = old_mass
+        return bounce

--- a/physics.py
+++ b/physics.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-from sys import float_info
 from typing import TYPE_CHECKING
 
 from pygame import Color
@@ -16,7 +15,6 @@ from constants import (
     BOUNCE_DAMAGE_SCALAR,
     BOUNCE_DAMAGE_THRESHOLD,
     BOUNCINESS,
-    EPSILON,
     GRAVITATIONAL_CONSTANT,
 )
 

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -43,6 +43,33 @@ def test_threedimensional_disk_mass_scaling():
     )
 
 
+def test_relative_bounce():
+    color = Color(0, 0, 0)
+
+    # Bounces should work the same if the disks have the same velocity relative
+    # to each other. So if we add an absolute_vel to their velocities, the
+    # result shouldn't change.
+    for absolute_vel in [30 * Vec2(i, j) for i in range(-1, 2) for j in range(-1, 2)]:
+        absolute_bounces: list[tuple[Disk, Disk]] = []
+
+        for relative_vel in [30 * Vec2(i, j) for i in range(-1, 2) for j in range(-1, 2)]:
+            disk_a = Disk(Vec2(), relative_vel + absolute_vel, 1, 1, color)
+            disk_b = Disk(Vec2(), relative_vel, 1.23, 1, color)
+
+            disk_a.bounce_off_of_disk(disk_b)
+            absolute_bounces.append((disk_a, disk_b))
+
+        # All the relative bounces should turn out the same
+        comparison_a, comparison_b = absolute_bounces[0]
+        for disk_a, disk_b in absolute_bounces[1:]:
+            assert (disk_a.pos - disk_b.pos - comparison_a.pos + comparison_b.pos).magnitude() < EPSILON, (
+                "Bounce positions should agree relatively"
+            )
+            assert (disk_a.vel - disk_b.vel - comparison_a.vel + comparison_b.vel).magnitude() < EPSILON, (
+                "Bounce velocities should agree relatively"
+            )
+
+
 def test_disk_drawing():
     width, height = 50, 50
     color = Color(255, 0, 0)

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -54,7 +54,7 @@ def test_relative_bounce():
 
         for relative_vel in [30 * Vec2(i, j) for i in range(-1, 2) for j in range(-1, 2)]:
             disk_a = Disk(Vec2(), relative_vel + absolute_vel, 1, 1, color)
-            disk_b = Disk(Vec2(), relative_vel, 1.23, 1, color)
+            disk_b = Disk(Vec2(1, 0), relative_vel, 1.23, 1, color)
 
             disk_a.bounce_off_of_disk(disk_b)
 

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -58,9 +58,9 @@ def test_relative_bounce():
             disk_a = Disk(Vec2(0, 0), absolute_vel + relative_vel, 1, 1, color)
             disk_b = Disk(Vec2(1, 0), absolute_vel, 1.23, 1, color)
 
-            print(relative_vel, disk_a.vel - disk_b.vel)
+            relative_vel, disk_a.vel - disk_b.vel
             disk_a.bounce_off_of_disk(disk_b)
-            print(relative_vel, disk_a.vel - disk_b.vel)
+            relative_vel, disk_a.vel - disk_b.vel
 
             assert disk_a.vel.y == (absolute_vel + relative_vel).y, (
                 "Disk's vertical velocity should be unchanged"

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -49,23 +49,27 @@ def test_relative_bounce():
     # Bounces should work the same if the disks have the same velocity relative
     # to each other. So if we add an absolute_vel to their velocities, the
     # result shouldn't change.
-    for absolute_vel in [30 * Vec2(i, j) for i in range(-1, 2) for j in range(-1, 2)]:
+    # The disks shouldn't be moving apart from each other, otherwise bounce_off_of_disk is a no-op,
+    # so only use these velocities:
+    for relative_vel in [Vec2(10, 5), Vec2(10, 0), Vec2(10, -20)]:
         absolute_bounces: list[tuple[Disk, Disk]] = []
 
-        for relative_vel in [30 * Vec2(i, j) for i in range(-1, 2) for j in range(-1, 2)]:
-            disk_a = Disk(Vec2(), relative_vel + absolute_vel, 1, 1, color)
-            disk_b = Disk(Vec2(1, 0), relative_vel, 1.23, 1, color)
+        for absolute_vel in [30 * Vec2(i, j) for i in range(-1, 2) for j in range(-1, 2)]:
+            disk_a = Disk(Vec2(0, 0), absolute_vel + relative_vel, 1, 1, color)
+            disk_b = Disk(Vec2(1, 0), absolute_vel, 1.23, 1, color)
 
+            print(relative_vel, disk_a.vel - disk_b.vel)
             disk_a.bounce_off_of_disk(disk_b)
+            print(relative_vel, disk_a.vel - disk_b.vel)
 
-            assert disk_a.vel.y == (relative_vel + absolute_vel).y, (
+            assert disk_a.vel.y == (absolute_vel + relative_vel).y, (
                 "Disk's vertical velocity should be unchanged"
             )
-            assert disk_a.vel.x < (relative_vel + absolute_vel).x - 0.1, (
+            assert disk_a.vel.x < (absolute_vel + relative_vel).x - 0.1, (
                 "Disk's horizontal velocity should be reduced"
             )
-            assert disk_b.vel.y == relative_vel.y, "Disk's vertical velocity should be unchanged"
-            assert disk_b.vel.x == relative_vel.x, "Disk's horizontal velocity should be unchanged"
+            assert disk_b.vel.y == absolute_vel.y, "Disk's vertical velocity should be unchanged"
+            assert disk_b.vel.x == absolute_vel.x, "Disk's horizontal velocity should be unchanged"
 
             absolute_bounces.append((disk_a, disk_b))
 

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -57,6 +57,16 @@ def test_relative_bounce():
             disk_b = Disk(Vec2(), relative_vel, 1.23, 1, color)
 
             disk_a.bounce_off_of_disk(disk_b)
+
+            assert disk_a.vel.y == (relative_vel + absolute_vel).y, (
+                "Disk's vertical velocity should be unchanged"
+            )
+            assert disk_a.vel.x < (relative_vel + absolute_vel).x - 0.1, (
+                "Disk's horizontal velocity should be reduced"
+            )
+            assert disk_b.vel.y == relative_vel.y, "Disk's vertical velocity should be unchanged"
+            assert disk_b.vel.x == relative_vel.x, "Disk's horizontal velocity should be unchanged"
+
             absolute_bounces.append((disk_a, disk_b))
 
         # All the relative bounces should turn out the same

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -56,7 +56,6 @@ def test_mutual_bounce():
         universe = Universe(Vec2(30, 30), [], [], [], [])
         universe.asteroids.append(asteroid_a)
         universe.asteroids.append(asteroid_b)
-        print(absolute_vel, relative_vel)
 
         for _ in range(150):
             universe.step(0.01)

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -56,7 +56,6 @@ def test_mutual_bounce():
         universe = Universe(Vec2(30, 30), [], [], [], [])
         universe.asteroids.append(asteroid_a)
         universe.asteroids.append(asteroid_b)
-        print(asteroid_a.vel)
 
         for _ in range(150):
             universe.step(0.01)
@@ -66,7 +65,9 @@ def test_mutual_bounce():
             "The asteroids shouldn't move vertically at all"
         )
         # Test related to https://github.com/Tim2othy/spacegame/issues/9
-        )
-        assert 0 > asteroid_a.vel.x > (absolute_vel - relative_vel).x * 0.99, (
+        assert absolute_vel.x > asteroid_a.vel.x > (absolute_vel - relative_vel).x - 0.1, (
             "asteroid_a should be moving to the left with less speed"
+        )
+        assert absolute_vel.x < asteroid_b.vel.x < (absolute_vel + relative_vel).x - 0.1, (
+            "asteroid_b should be moving to the right with less speed"
         )

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -41,31 +41,32 @@ def test_planet_gravitation():
 
 
 def test_mutual_bounce():
-    start_y = 15
-    start_vel = 5
-    asteroid_moving_rightward = Asteroid(Vec2(10, start_y), Vec2(start_vel, 0), 1, 1)
-    asteroid_moving_leftward = Asteroid(Vec2(20, start_y), Vec2(-start_vel, 0), 2, 0.9)
+    # Bounces should be relative to the two asteroids'
+    # velocities:
+    for absolute_vel in [30 * Vec2(i, j) for i in range(-1, 2) for j in range(-1, 2)]:
+        start_y = 15
+        relative_vel = Vec2(5, 0)
+        # Boost both asteroids by absolute_vel
+        asteroid_moving_rightward = Asteroid(Vec2(10, start_y), absolute_vel + relative_vel, 1, 1)
+        asteroid_moving_leftward = Asteroid(Vec2(20, start_y), absolute_vel - relative_vel, 2, 0.9)
 
-    universe = Universe(Vec2(30, 30), [], [], [], [])
-    universe.asteroids.append(asteroid_moving_rightward)
-    universe.asteroids.append(asteroid_moving_leftward)
+        universe = Universe(Vec2(30, 30), [], [], [], [])
+        universe.asteroids.append(asteroid_moving_rightward)
+        universe.asteroids.append(asteroid_moving_leftward)
 
-    for _ in range(150):
-        universe.step(0.01)
+        for _ in range(150):
+            universe.step(0.01)
 
-    assert asteroid_moving_rightward.pos.x < asteroid_moving_leftward.pos.x, (
-        "The asteroids shouldn't fly past each other"
-    )
-    assert asteroid_moving_rightward.pos.y == asteroid_moving_leftward.pos.y == start_y, (
-        "The asteroid shouldn't move vertically at all"
-    )
-    assert asteroid_moving_rightward.vel.y == asteroid_moving_leftward.vel.y == 0, (
-        "The asteroid shouldn't move vertically at all"
-    )
-    # Test related to https://github.com/Tim2othy/spacegame/issues/9
-    assert 0 < asteroid_moving_rightward.vel.x < start_vel * 0.99, (
-        "The right asteroid should be moving to the right with less speed"
-    )
-    assert 0 > asteroid_moving_rightward.vel.x > -start_vel * 0.99, (
-        "The left asteroid should be moving to the left with less speed"
-    )
+        assert asteroid_moving_rightward.pos.x < asteroid_moving_leftward.pos.x, (
+            "The asteroids shouldn't fly past each other"
+        )
+        assert asteroid_moving_rightward.vel.y == asteroid_moving_leftward.vel.y == absolute_vel.y, (
+            "The asteroids shouldn't move vertically at all"
+        )
+        # Test related to https://github.com/Tim2othy/spacegame/issues/9
+        assert 0 < asteroid_moving_rightward.vel.x < (absolute_vel + relative_vel).x * 0.99, (
+            "The right asteroid should be moving to the right with less speed"
+        )
+        assert 0 > asteroid_moving_rightward.vel.x > (absolute_vel - relative_vel).x * 0.99, (
+            "The left asteroid should be moving to the left with less speed"
+        )

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -56,6 +56,7 @@ def test_mutual_bounce():
         universe = Universe(Vec2(30, 30), [], [], [], [])
         universe.asteroids.append(asteroid_a)
         universe.asteroids.append(asteroid_b)
+        print(asteroid_a.vel)
 
         for _ in range(150):
             universe.step(0.01)
@@ -65,8 +66,6 @@ def test_mutual_bounce():
             "The asteroids shouldn't move vertically at all"
         )
         # Test related to https://github.com/Tim2othy/spacegame/issues/9
-        assert 0 < asteroid_b.vel.x < (absolute_vel + relative_vel).x * 0.99, (
-            "asteroid_b should be moving to the right with less speed"
         )
         assert 0 > asteroid_a.vel.x > (absolute_vel - relative_vel).x * 0.99, (
             "asteroid_a should be moving to the left with less speed"

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -41,32 +41,34 @@ def test_planet_gravitation():
 
 
 def test_mutual_bounce():
-    # Bounces should be relative to the two asteroids'
-    # velocities:
+    # Two asteroids
+    #  o   →               ←   O
+    #  asteroid_a     asteroid_b
+
+    # Bounces should be relative to the two asteroids' velocities:
     for absolute_vel in [30 * Vec2(i, j) for i in range(-1, 2) for j in range(-1, 2)]:
         start_y = 15
         relative_vel = Vec2(5, 0)
         # Boost both asteroids by absolute_vel
-        asteroid_moving_rightward = Asteroid(Vec2(10, start_y), absolute_vel + relative_vel, 1, 1)
-        asteroid_moving_leftward = Asteroid(Vec2(20, start_y), absolute_vel - relative_vel, 2, 0.9)
+        asteroid_a = Asteroid(Vec2(10, start_y), absolute_vel + relative_vel, 1, 1)
+        asteroid_b = Asteroid(Vec2(20, start_y), absolute_vel - relative_vel, 2, 0.9)
 
         universe = Universe(Vec2(30, 30), [], [], [], [])
-        universe.asteroids.append(asteroid_moving_rightward)
-        universe.asteroids.append(asteroid_moving_leftward)
+        universe.asteroids.append(asteroid_a)
+        universe.asteroids.append(asteroid_b)
+        print(absolute_vel, relative_vel)
 
         for _ in range(150):
             universe.step(0.01)
 
-        assert asteroid_moving_rightward.pos.x < asteroid_moving_leftward.pos.x, (
-            "The asteroids shouldn't fly past each other"
-        )
-        assert asteroid_moving_rightward.vel.y == asteroid_moving_leftward.vel.y == absolute_vel.y, (
+        assert asteroid_a.pos.x < asteroid_b.pos.x, "The asteroids shouldn't fly past each other"
+        assert asteroid_a.vel.y == asteroid_b.vel.y == absolute_vel.y, (
             "The asteroids shouldn't move vertically at all"
         )
         # Test related to https://github.com/Tim2othy/spacegame/issues/9
-        assert 0 < asteroid_moving_rightward.vel.x < (absolute_vel + relative_vel).x * 0.99, (
-            "The right asteroid should be moving to the right with less speed"
+        assert 0 < asteroid_b.vel.x < (absolute_vel + relative_vel).x * 0.99, (
+            "asteroid_b should be moving to the right with less speed"
         )
-        assert 0 > asteroid_moving_rightward.vel.x > (absolute_vel - relative_vel).x * 0.99, (
-            "The left asteroid should be moving to the left with less speed"
+        assert 0 > asteroid_a.vel.x > (absolute_vel - relative_vel).x * 0.99, (
+            "asteroid_a should be moving to the left with less speed"
         )

--- a/universe.py
+++ b/universe.py
@@ -192,6 +192,9 @@ class Universe:
 
     def collide_bullets(self) -> None:
         """Run bullet-collision checks and damage ships as a result."""
+
+        # TODO: Use memory-hack to make bullet-removal faster, use indices and python's analogue
+        # of https://doc.rust-lang.org/std/vec/struct.Vec.html#method.swap_remove
         for player_ship in self.player_ships:
             for projectile in player_ship.projectiles:
                 if self.asteroids_or_planets_intersect_point(

--- a/universe.py
+++ b/universe.py
@@ -143,7 +143,6 @@ class Universe:
 
     def apply_bounce(self) -> None:
         """Run all bounce-interactions within `self`."""
-
         # Bounce-Hierarchy:
         # player_ships > enemy_ships > asteroids
         # Planets are separate.

--- a/universe.py
+++ b/universe.py
@@ -141,50 +141,39 @@ class Universe:
         for pobj in self.player_ships + self.enemy_ships + self.asteroids:
             self.apply_gravity_to_obj(dt, pobj)
 
-    def apply_bounce_to_disk(self, disk: Disk) -> float | None:
-        """Bounce a disk off of each of `self`s objects.
-
-        Args:
-        ----
-            disk (Disk): Disk to bounce
-
-        Returns:
-        -------
-            float | None: If float, impact velocity of first bounce.
-                If None, no impact occured.
-
-        """
-        for body in self.asteroids + self.planets:
-            damage = disk.bounce_off_of_disk(body)
-            if damage is not None:
-                return damage
-        return None
-
     def apply_bounce(self) -> None:
         """Run all bounce-interactions within `self`."""
-        for player_ship in self.player_ships:
-            damage = self.apply_bounce_to_disk(player_ship)
-            if damage is not None:
-                player_ship.suffer_damage(damage)
-        for enemy_ship in self.enemy_ships:
-            self.apply_bounce_to_disk(enemy_ship)
 
-        # Create a new list to store asteroids that have not collided
-        remaining_asteroids = []
-        for asteroid in self.asteroids:
-            collided = False
+        # Bounce-Hierarchy:
+        # player_ships > enemy_ships > asteroids
+        # Planets are separate.
+
+        # Bounce player_ships
+        for player in self.player_ships:
+            # For now, don't bounce player-ships off of other player-ships
+            for body in self.enemy_ships + self.asteroids:
+                if damage := player.bounce_disks(body) is not None:
+                    player.suffer_damage(damage)
             for planet in self.planets:
-                if asteroid.intersects_disk(planet):
-                    collided = True
-                    break
-            if not collided:
-                remaining_asteroids.append(asteroid)
-        self.asteroids = remaining_asteroids
+                if damage := player.bounce_off_of_disk(planet) is not None:
+                    player.suffer_damage(damage)
 
-        for asteroid in self.asteroids:
-            other_asteroids = [ast for ast in self.asteroids if ast != asteroid]
-            for disk in other_asteroids + self.planets:
-                asteroid.bounce_off_of_disk(disk)
+        # Bounce enemy_ships
+        for ix, enemy_ship in enumerate(self.enemy_ships):
+            # But it *is* fun to bounce enemies off of each other
+            for body in self.enemy_ships[ix + 1 :] + self.asteroids:
+                # TODO: Once enemies have proper health, they should probably suffer damage, too
+                enemy_ship.bounce_disks(body)
+            for planet in self.planets:
+                # TODO: Once enemies have proper health, they should probably suffer damage, too
+                enemy_ship.bounce_off_of_disk(planet)
+
+        # Bounce asteroids
+        for ix, asteroid in enumerate(self.asteroids):
+            for body in self.asteroids[ix + 1 :]:
+                asteroid.bounce_disks(body)
+            for planet in self.planets:
+                asteroid.bounce_off_of_disk(planet)
 
     def asteroids_or_planets_intersect_point(self, vec: Vec2) -> bool:
         """Test whether any of `self`'s planets or asteroids intersect `vec`.


### PR DESCRIPTION
Closes #9. Implements a `Disk.bounce_disks` method that's quite similar to the previous asymmetric version, but:
- Applies impulse-change to both disks
- Moves the disks apart from each other, scaling with their relative mass. For example, if someone shot kinetic projectiles in the form of many small disks at a huge asteroid, you wouldn't expect the asteroid to move much at all, so the separation needs to be scaled accordingly.
- The impulse-vector is now calculated off of the two disks' *relative velocity*. Originally, it was only calculated off of the first disk's velocity, violating relativity.

The `bounce_off_of_disk` method still exists, but now implemented as:
```py
        # HACK: Treat the static disk as if it had infinite mass
        old_mass, disk.mass = disk.mass, float("inf")
        bounce = self.bounce_disks(disk)
        disk.mass = old_mass
        return bounce
```
Feel free to judge.

Asteroids crashing into planets are no longer destroyed, let me know if that should be re-added (I know a faster way to remove an Asteroid from the list `universe.asteroid` than the old implementation, which I also hope to implement for colliding bullets, cf 6f49986f08c7f5fb78920c87b8a6064fa54ef90b).

Lastly, there is a new (passing) test to verify that disks' collision obey relativity of their velocities, and `tests/test_universe.py::test_mutual_bounce` now passes as well.