### PR TITLE
Remove-density

### DIFF
--- a/physics.py
+++ b/physics.py
@@ -102,7 +102,7 @@ GRAY = Color("gray")
 class Disk(PhysicalObject):
     """A disk-shaped PhysicalObject, with constant radius and dynamic color."""
 
-    def __init__(self, pos: Vec2, vel: Vec2, radius: float, color: Color = GRAY, density: float = 1) -> None:
+    def __init__(self, pos: Vec2, vel: Vec2, radius: float, color: Color = GRAY) -> None:
         """Create a new Disk. Mass will be calculated as if it were a sphere, though.
 
         Args:
@@ -110,10 +110,9 @@ class Disk(PhysicalObject):
             vel (Vec2): Disk's velocity
             radius (float): Disk's radius
             color (pygame.Color): Disk's color
-            density (float): Disk's density
 
         """
-        mass = radius**3 * math.pi * 4 / 3 * density
+        mass = radius**3 * math.pi * 4 / 3
         super().__init__(pos, vel, mass)
         self.radius = radius
         self.color = Color(color)
@@ -137,7 +136,7 @@ class Disk(PhysicalObject):
         Returns:
             bool: True iff `vec` is in `self`
 
-        >>> disk = Disk(Vec2(0,0), Vec2(), density=1, radius=2, color=Color(0, 0, 0))
+        >>> disk = Disk(Vec2(0,0), Vec2(), radius=2, color=Color(0, 0, 0))
         >>> disk.intersects_point(Vec2(0, 0))
         True
         >>> disk.intersects_point(Vec2(1, -1))
@@ -160,11 +159,11 @@ class Disk(PhysicalObject):
         Returns:
             bool: True iff the two disks intersect
 
-        >>> disk_a = Disk(Vec2(0,0), Vec2(), density=1, radius=2, color=Color(0, 0, 0))
-        >>> disk_b = Disk(Vec2(2,1), Vec2(), density=1, radius=1, color=Color(0, 0, 0))
+        >>> disk_a = Disk(Vec2(0,0), Vec2(), radius=2, color=Color(0, 0, 0))
+        >>> disk_b = Disk(Vec2(2,1), Vec2(), radius=1, color=Color(0, 0, 0))
         >>> disk_a.intersects_disk(disk_b) or disk_b.intersects_disk(disk_a)
         True
-        >>> disk_c = Disk(Vec2(3,1), Vec2(), density=1, radius=0.5, color=Color(0, 0, 0))
+        >>> disk_c = Disk(Vec2(3,1), Vec2(), radius=0.5, color=Color(0, 0, 0))
         >>> disk_a.intersects_disk(disk_c) or disk_c.intersects_disk(disk_a)
         False
         >>> disk_b.intersects_disk(disk_c) and disk_c.intersects_disk(disk_b)

--- a/ship.py
+++ b/ship.py
@@ -63,7 +63,7 @@ class Ship(Disk):
         ValueError
 
         """
-        super().__init__(pos, vel, size, color, 1)
+        super().__init__(pos, vel, size, color)
         self.size: float = size
 
         self.health: float = 100.0

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -51,7 +51,7 @@ def test_bullet_paths():
     ]
 
     for enemy_right, enemy_up in enemy_groups:
-        asteroid = Asteroid(player_ship.pos + Vec2(250, 0), Vec2(0, 0), 1, 20)
+        asteroid = Asteroid(player_ship.pos + Vec2(250, 0), Vec2(0, 0), 1)
         universe = Universe(
             world,
             [],

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -55,8 +55,8 @@ def test_relative_bounce():
         absolute_bounces: list[tuple[Disk, Disk]] = []
 
         for absolute_vel in [30 * Vec2(i, j) for i in range(-1, 2) for j in range(-1, 2)]:
-            disk_a = Disk(Vec2(0, 0), absolute_vel + relative_vel, 1, density=1)
-            disk_b = Disk(Vec2(1, 0), absolute_vel, 1, density=1.23)
+            disk_a = Disk(Vec2(0, 0), absolute_vel + relative_vel, 1)
+            disk_b = Disk(Vec2(1, 0), absolute_vel, 1)
 
             relative_vel, disk_a.vel - disk_b.vel
             disk_a.bounce_off_of_disk(disk_b)
@@ -130,12 +130,12 @@ def test_disk_drawing():
 
 
 def test_disk_bounce():
-    disk_a = Disk(Vec2(0, 0), Vec2(0, 0), density=1, radius=1, color=Color(0, 0, 0))
-    disk_b = Disk(Vec2(4, 0), Vec2(0, 0), density=1, radius=2, color=Color(0, 0, 0))
+    disk_a = Disk(Vec2(0, 0), Vec2(0, 0), radius=1, color=Color(0, 0, 0))
+    disk_b = Disk(Vec2(4, 0), Vec2(0, 0), radius=2, color=Color(0, 0, 0))
 
     assert disk_a.bounce_off_of_disk(disk_b) is None, "Non-intersecting disks shouldn't bounce"
 
-    disk_c = Disk(Vec2(0, 1), Vec2(1, 0), density=1, radius=1, color=Color(0, 0, 0))
+    disk_c = Disk(Vec2(0, 1), Vec2(1, 0), radius=1, color=Color(0, 0, 0))
 
     bounce_count = 0
     for _ in range(200):

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -29,6 +29,7 @@ def test_gravitational_force():
     assert abs(2 - large_force.magnitude() / small_force.magnitude()) < EPSILON
     assert abs(4 - small_force.magnitude() / double_distance_force.magnitude()) < EPSILON
 
+""" Is this still useful with density gone?
 
 def test_threedimensional_disk_mass_scaling():
     density = 9.87
@@ -41,6 +42,7 @@ def test_threedimensional_disk_mass_scaling():
     assert abs(2**3 - double_size_disk.mass / disk.mass) < EPSILON, (
         "Scaling radius should increase mass by a factor scale**3"
     )
+    """
 
 
 def test_relative_bounce():

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 def test_planet_gravitation():
     world = Vec2(3000, 3000)
-    planet = Planet(world / 2, 1000, Color(0, 0, 0), 1)
+    planet = Planet(world / 2, 1000, Color(0, 0, 0))
     player = PlayerShip(world / 4, Vec2(100, -200))
     enemy = BulletEnemy(3 * world / 4, Vec2(100, -200), player)
 
@@ -45,8 +45,8 @@ def test_mutual_bounce():
         start_y = 15
         relative_vel = Vec2(5, 0)
         # Boost both asteroids by absolute_vel
-        asteroid_a = Asteroid(Vec2(10, start_y), absolute_vel + relative_vel, 1, 1)
-        asteroid_b = Asteroid(Vec2(20, start_y), absolute_vel - relative_vel, 0.9, 2)
+        asteroid_a = Asteroid(Vec2(10, start_y), absolute_vel + relative_vel, 1)
+        asteroid_b = Asteroid(Vec2(20, start_y), absolute_vel - relative_vel, 0.9)
 
         universe = Universe(Vec2(30, 30), [], [], [], max(asteroid_a.radius, asteroid_b.radius) * 2)
         universe.add_asteroids(asteroid_a, asteroid_b)

--- a/universe.py
+++ b/universe.py
@@ -34,33 +34,31 @@ from constants import (
 class Planet(Disk):
     """A stationary disk."""
 
-    def __init__(self, pos: Vec2, radius: float, color: Color, density: float = 1) -> None:
+    def __init__(self, pos: Vec2, radius: float, color: Color) -> None:
         """Create a new planet.
 
         Args:
             pos (Vec2): Fixed position
             radius (float): Radius
             color (Color): Color
-            density (float): Density
 
         """
-        super().__init__(pos, Vec2(0, 0), radius, color, density)
+        super().__init__(pos, Vec2(0, 0), radius, color)
 
 
 class Asteroid(Disk):
     """A gray disk that doesn't exert gravitational force, and isn't stationary."""
 
-    def __init__(self, pos: Vec2, vel: Vec2, radius: float, density: float = 1) -> None:
+    def __init__(self, pos: Vec2, vel: Vec2, radius: float) -> None:
         """Create a new Asteroid.
 
         Args:
             pos (Vec2): Initial position
             vel (Vec2): Initial velocity
             radius (float): Radius
-            density (float): Density
 
         """
-        super().__init__(pos, vel, radius, Color(32, 32, 32), density)
+        super().__init__(pos, vel, radius, Color(32, 32, 32))
 
 
 type AsteroidChunk = tuple[int, int]
@@ -584,4 +582,4 @@ class Universe:
         tangential_vector = radial_vector.rotate(asteroid_angle)
         velocity_asteroid = tangential_vector * orbital_velocity
 
-        self.add_asteroids(Asteroid(pos_asteroid, velocity_asteroid, 1, radius_asteroid))
+        self.add_asteroids(Asteroid(pos_asteroid, velocity_asteroid, radius_asteroid))


### PR DESCRIPTION
Removed any mention of the density parameter, all PhysicalObjects now assume density is 1 when calculating their mass.

The test are modified to reflect this change aswell. One test test_threedimensional_disk_mass_scaling is commented out now, it only really makes sense when density is a thing, the other tests all pass with density removed.