### PR TITLE
Move constants

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,23 +1,10 @@
-"""Constants for the game.
+"""Constants for the game."""
 
-TODO: We should put most of these into their respective modules.
-"""
-
-from pygame import Color
-from pygame.math import Vector2 as Vec2
-
-SCREEN_SIZE = Vec2(1700, 900)
-FPS_HISTORY_LENGTH = 180  # how many frames to keep for FPS calculation
-
-
-# Enemy Action and Spawn
-ENEMY_SPAWN_WEIGHTS = [0.3, 0.3, 0.2, 0.2]
+# TODO: Once all ships adopt MarkovAI, these constanst are probably only needed in one module, so then
+# we can inline them there.
 ENEMY_FIRE_RANGE_SQUARED = 1700**2
 ENEMY_VISUAL_RANGE_SQUARED = 2000**2
 ENEMY_ACTION_TIMER = 6
-ENEMY_ACTION_WEIGHTS = [1.0]
-
-THRUST_COLOR = Color("orange")
 
 
 # Added speed at release
@@ -27,31 +14,4 @@ FLARE_MEAN_RELEASE_SPEED = 140
 FLARE_SD_RELEASE_SPEED = 28
 
 
-# Constants for state transitions
-RETREAT_HEALTH = 30.0
-DESIRED_APPROACH_SPEED = 500
-
 GRAVITATIONAL_CONSTANT = 0.02
-EPSILON = 1e-8
-
-
-GRID_COLOR = Color("darkgreen")
-
-
-def generate_complementary_color(base_color: Color) -> Color:
-    """Generate a complementary bullet color based on a color.
-
-    >>> generate_complementary_color(Color("red"))  # should return cyan
-    Color(0, 255, 255, 255)
-    >>> generate_complementary_color(Color("white"))  # should return white
-    Color(255, 255, 255, 255)
-    >>> generate_complementary_color(Color(0, 128, 0))  # dark green, should return violet
-    Color(166, 0, 166, 255)
-    """
-    h, s, v, a = base_color.hsva
-
-    new_h = (h + 180.0) % 360.0  # Shift hue by 180° for complementary color
-    new_s = min(100.0, s * 1.2)  # Slightly more saturated
-    new_v = min(100.0, v * 1.3)  # Slightly brighter
-
-    return Color.from_hsva(new_h, new_s, new_v, a)

--- a/enemy_ai.py
+++ b/enemy_ai.py
@@ -11,12 +11,13 @@ from pygame.math import Vector2 as Vec2
 
 from constants import (
     BULLET_RELEASE_SPEED,
-    DESIRED_APPROACH_SPEED,
     ENEMY_ACTION_TIMER,
     ENEMY_FIRE_RANGE_SQUARED,
     ENEMY_VISUAL_RANGE_SQUARED,
-    RETREAT_HEALTH,
 )
+
+RETREAT_HEALTH_THRESHOLD = 30.0
+DESIRED_APPROACH_SPEED = 500
 
 if TYPE_CHECKING:
     from ship import Ship
@@ -97,7 +98,7 @@ class MarkovAI:
         """
         # Get context information
         can_see_player = self.target.distance_squared_to(self.ship) < ENEMY_VISUAL_RANGE_SQUARED
-        low_health = self.ship.health < RETREAT_HEALTH
+        low_health = self.ship.health < RETREAT_HEALTH_THRESHOLD
 
         # Simply select the appropriate pre-computed matrix based on context
         if can_see_player and low_health:

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import platform
 import sys
-from collections import deque
 from dataclasses import fields
 from typing import TYPE_CHECKING
 
@@ -14,12 +13,13 @@ from pygame import Color, Surface
 from pygame.font import Font
 
 from camera import Camera
-from constants import FPS_HISTORY_LENGTH, SCREEN_SIZE
 from profiler import global_profiler
 from universe import Universe, UniverseOptions
 
 if TYPE_CHECKING:
     from ship import PlayerShip
+
+SCREEN_SIZE = pygame.math.Vector2(1700, 900)
 
 
 async def main() -> None:
@@ -49,7 +49,6 @@ async def main() -> None:
 
         clock = pygame.time.Clock()
 
-        fps: deque[float] = deque()
         running = True
 
         while running:
@@ -59,9 +58,6 @@ async def main() -> None:
                 break
 
             dt = clock.tick() / 1_000
-            fps.append(clock.get_fps())
-            if len(fps) > FPS_HISTORY_LENGTH:
-                fps.popleft()
 
             universe.handle_input(pygame.key.get_pressed())
             universe.step(dt)
@@ -78,7 +74,7 @@ async def main() -> None:
                     break
                 camera.step()
                 universe.draw(camera)
-                universe.draw_text(camera, player, sum(fps) / len(fps))
+                universe.draw_text(camera, player, clock.get_fps())
 
             pygame.display.flip()
             await asyncio.sleep(0)

--- a/projectiles.py
+++ b/projectiles.py
@@ -11,14 +11,13 @@ from physics import Body, Pos, PosVel
 if TYPE_CHECKING:
     from ship import Ship
 
-from constants import THRUST_COLOR
-
 # Damage
 BULLET_DAMAGE = 16
 ROCKET_DAMAGE = 26
 MISSILE_DAMAGE = 60
 FLARE_DAMAGE = 10
 # Thrust
+ROCKET_THRUST_COLOR = Color("orange")
 ROCKET_HOMING_THRUST = 300.0
 MISSILE_HOMING_THRUST = 600.0
 # Homing
@@ -102,7 +101,7 @@ class Rocket(Bullet):
         if current_cycle < ROCKET_TIMES_HOMES and is_homing_phase:
             # Thrust flame
             camera.draw_polygon(
-                self.color.lerp(THRUST_COLOR, 0.5),
+                self.color.lerp(ROCKET_THRUST_COLOR, 0.5),
                 [
                     Pos(self, 3 * (left + backward)),
                     Pos(self, 4 * (left + 2 * backward)),

--- a/ship.py
+++ b/ship.py
@@ -15,13 +15,10 @@ from pygame.math import Vector2 as Vec2
 from constants import (
     BULLET_RELEASE_SPEED,
     ENEMY_ACTION_TIMER,
-    ENEMY_ACTION_WEIGHTS,
     ENEMY_VISUAL_RANGE_SQUARED,
     FLARE_MEAN_RELEASE_SPEED,
     FLARE_SD_RELEASE_SPEED,
     ROCKET_RELEASE_SPEED,
-    THRUST_COLOR,
-    generate_complementary_color,
 )
 from enemy_ai import MarkovAI
 from physics import Disk, Pos, PosVel
@@ -37,6 +34,7 @@ MISSILE_RATE_OF_FIRE = 3.0
 FLARE_RATE_OF_FIRE = 5.0
 
 GRAY = Color("gray")
+THRUST_COLOR = Color("orange")
 BULLET_ENEMY_COLOR = Color("lightblue")
 ROCKET_ENEMY_COLOR = Color("purple")
 MISSILE_ENEMY_COLOR = Color("lime")
@@ -50,6 +48,25 @@ DAMAGE_INDICATOR_TIME = 1
 """Time (in seconds) a ship should flash red after taking damage"""
 NUM_FLARES = 40
 SD_FLARE_ANGLE = 25
+
+
+def generate_complementary_color(base_color: Color) -> Color:
+    """Generate a complementary bullet color based on a color.
+
+    >>> generate_complementary_color(Color("red"))  # should return cyan
+    Color(0, 255, 255, 255)
+    >>> generate_complementary_color(Color("white"))  # should return white
+    Color(255, 255, 255, 255)
+    >>> generate_complementary_color(Color(0, 128, 0))  # dark green, should return violet
+    Color(166, 0, 166, 255)
+    """
+    h, s, v, a = base_color.hsva
+
+    new_h = (h + 180.0) % 360.0  # Shift hue by 180° for complementary color
+    new_s = min(100.0, s * 1.2)  # Slightly more saturated
+    new_v = min(100.0, v * 1.3)  # Slightly brighter
+
+    return Color.from_hsva(new_h, new_s, new_v, a)
 
 
 @dataclass
@@ -442,12 +459,7 @@ class BulletEnemy(Ship):
             if can_see_target:
                 self.current_action = BulletEnemy.Action.accelerate_to_player
             else:
-                [self.current_action] = random.choices(
-                    population=[
-                        BulletEnemy.Action.accelerate_randomly,
-                    ],
-                    weights=ENEMY_ACTION_WEIGHTS,
-                )
+                self.current_action = BulletEnemy.Action.accelerate_randomly
 
                 if self.current_action == BulletEnemy.Action.accelerate_randomly:
                     # Accelerate towards a random point near the player.

--- a/universe.py
+++ b/universe.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from projectiles import Bullet
     from ship import Ship
 
-from constants import ENEMY_SPAWN_WEIGHTS, FPS_HISTORY_LENGTH, GRAVITATIONAL_CONSTANT, GRID_COLOR
+from constants import GRAVITATIONAL_CONSTANT
 
 PLANET_SIZE_PARAMETER = 5.9
 SIGMA_PLANET_RADIUS = 0.3
@@ -504,7 +504,7 @@ class Universe:
             return vertical_offset + font_size
 
         text_v = 10
-        text_v = texty(text_v, f"{fps:.0f} fps (average over past {FPS_HISTORY_LENGTH} frames)")
+        text_v = texty(text_v, f"{fps:.0f} fps")
         text_v = texty(text_v, f"Health: {player.health:.0f}")
 
         enemy_count = len(self._enemy_ships)
@@ -523,6 +523,7 @@ class Universe:
         gridline_spacing = 500
         width = 3000
         height = 3000
+        GRID_COLOR = Color("darkgreen")
 
         for x in range(0, int(width + 1), gridline_spacing):
             camera.draw_vertical_hairline(GRID_COLOR, x, 0, height)
@@ -616,7 +617,8 @@ class Universe:
             vec = Vec2(0, 0)
             vec.from_polar((random_radius, random_angle))
 
-            enemy_type = random.choices([BulletEnemy, RocketEnemy, MissileEnemy, MarkovEnemy], ENEMY_SPAWN_WEIGHTS)[0]
+            enemy_spawn_weights = [0.3, 0.3, 0.2, 0.2]
+            enemy_type = random.choices([BulletEnemy, RocketEnemy, MissileEnemy, MarkovEnemy], enemy_spawn_weights)[0]
             targeting = random.choice(player_ships)
 
             universe.add_enemy(EnemyConfig(relative_pos=vec, target_ship=targeting), enemy_type)


### PR DESCRIPTION
Constants that can reasonably be local should be local, which fixes #81. Other changes:

- Remove fps-queue, clock.get_fps() already applies windowing
- Move `generate_complementary_color` to ship.py
- Remove unused constant EPSILON
- Give Rockets separate thrust-color
- Remove ENEMY_ACTION_WEIGHTS constant. The actions are chosen deterministically at the moment. Prior to the relativity-apocalypse, the enemies had extra actions, but some got removed, leading to determinism here. This enemy-ai will probably be entirely replaced by MarkovAI, anyway.