### PR TITLE
Draw particles with transparency

### DIFF
--- a/camera.py
+++ b/camera.py
@@ -61,11 +61,14 @@ class Camera(Pos):
         """Fill the camera's surface black to prepare for drawing a new frame."""
         self._surface.fill(Color("black"))
 
-    def draw_pixel(self, color: Color, pos: Pos) -> None:
+    def draw_pixel(self, color: Color, transparency: float, pos: Pos) -> None:
         """Draw a worldspace-pixel at position `pos`."""
         surfacepoint = self._world_to_surface(pos)
         if self._surface_rect.collidepoint(surfacepoint):
-            self._surface.set_at((int(surfacepoint.x), int(surfacepoint.y)), color)
+            position = (int(surfacepoint.x), int(surfacepoint.y))
+            old_color = self._surface.get_at(position)
+            new_color = old_color.lerp(color, transparency)
+            self._surface.set_at(position, new_color)
 
     def draw_circle(self, color: Color, center: Pos, radius: float) -> None:
         """Draw a worldspace-circle."""

--- a/physics.py
+++ b/physics.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
 
 from constants import GRAVITATIONAL_CONSTANT
 
-BLACK = Color("black")
 GRAY = Color("gray")
 
 
@@ -108,8 +107,7 @@ class Particle(PosVel):
 
     def draw(self, camera: Camera) -> None:
         """Draw `self` on `camera`."""
-        color = BLACK.lerp(self._base_color, max(0, min(1, self._lifetime / self._max_lifetime)))
-        camera.draw_pixel(color, self)
+        camera.draw_pixel(self._base_color, max(0, min(1, self._lifetime / self._max_lifetime)), self)
 
 
 class Body(PosVel):

--- a/universe.py
+++ b/universe.py
@@ -483,8 +483,6 @@ class Universe:
     def draw(self, camera: Camera, *, minimap: bool = False) -> None:
         """Draw all of `self` on `camera`."""
         if not minimap:
-            for particle in self._particles:
-                particle.draw(camera)
             self.draw_background(camera)
             self.draw_grid(camera)
 
@@ -493,6 +491,10 @@ class Universe:
 
         if isinstance(self.__star, Star):
             self.__star.draw(camera)
+
+        if not minimap:
+            for particle in self._particles:
+                particle.draw(camera)
 
     @global_profiler.profile_method
     def draw_text(self, camera: Camera, player: PlayerShip, fps: float) -> None:


### PR DESCRIPTION
We draw particles behind all other objects (planets, ships, bullets), because they faded to black over time: When on a black background (space), this looks perfectly fine, but them fading to black over a colored background (e.g. a yellow star) would look weird. They should fade to the background's color instead, which this achieves.

As a consequence, we can also draw particles on top of all other objects.

The exact solution used in the code here doesn't feel very idiomatic. It'd be more idiomatic to mix the colors after applying alpha to the particle's color, but pygame doesn't offer that.