### PR TITLE
Update build-instructions after move to /src

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ In `constants.py` you can control the size of the map (`SMALL_MODE`), whether th
 Requires [uv](https://docs.astral.sh/uv/), which installs all dependencies, including python, automatically. Running the game locally:
 
 ```sh
-uv run main.py
+uv run src/main.py
 ```
 
 Build the game for the web using pygbag (while this is running, open <localhost:8000>):
 
 ```sh
-uv run pygbag .
+uv run pygbag src/main.py
 ```
 
 Run tests with:


### PR DESCRIPTION
Source-files were moved from root to /src in f32237c6b5d9ac8c08b38cddf4f49fcb4670a869. This updates the build-instructions in the README to reflect that.

I also scoured the remaining repo for other references to source-files via `rg "\.py"`. Only architecture.md contained noteworthy references to `.py`-files, and I guess replacing things there doesn't really matter.