### PR TITLE
Boost flare-momentum based on exit-point

### DIFF
--- a/src/ship.py
+++ b/src/ship.py
@@ -246,7 +246,7 @@ class Ship(Mover):
                     flare_offset = -self.forward * flare_offset_distance
 
                     # Calculate tangential velocity component from ship's rotation
-                    perpendicular_direction = Vec2(-flare_direction.y, flare_direction.x)
+                    perpendicular_direction = Vec2(-flare_offset.y, flare_offset.x)
                     tangential_vel = perpendicular_direction * angular_vel_radians * flare_offset_distance
 
                     # Combine velocities for realistic momentum transfer

--- a/src/ship.py
+++ b/src/ship.py
@@ -234,6 +234,14 @@ class Ship(Mover):
                 # Convert angular velocity to radians for physics calculations
                 angular_vel_radians = math.radians(self.angular_velocity)
 
+                # Calculate flare position relative to ship
+                flare_exit_point_distance = self.radius * 1.2
+                flare_exit_point = -self.forward * flare_exit_point_distance
+
+                # Calculate tangential velocity component from ship's rotation
+                perpendicular_direction = Vec2(-flare_exit_point.y, flare_exit_point.x)
+                tangential_vel = perpendicular_direction * angular_vel_radians * flare_exit_point_distance
+
                 for _ in range(NUM_FLARES):
                     random_rotation = random.normalvariate(0, SD_FLARE_ANGLE)
                     flare_direction = self.forward.rotate(random_rotation)
@@ -241,17 +249,9 @@ class Ship(Mover):
                     # Calculate base velocity (opposite to flare direction)
                     base_vel = -flare_direction * random.normalvariate(FLARE_MEAN_RELEASE_SPEED, FLARE_SD_RELEASE_SPEED)
 
-                    # Calculate flare position relative to ship
-                    flare_offset_distance = self.radius * 1.2
-                    flare_offset = -self.forward * flare_offset_distance
-
-                    # Calculate tangential velocity component from ship's rotation
-                    perpendicular_direction = Vec2(-flare_offset.y, flare_offset.x)
-                    tangential_vel = perpendicular_direction * angular_vel_radians * flare_offset_distance
-
                     # Combine velocities for realistic momentum transfer
                     flare_vel = base_vel + tangential_vel
-                    self.projectiles.append(self.new_flare(flare_offset, flare_vel))
+                    self.projectiles.append(self.new_flare(flare_exit_point, flare_vel))
                 self.flare_cooldown_timer += FLARE_RATE_OF_FIRE
 
     def suffer_damage(self, damage: float) -> None:


### PR DESCRIPTION
Making the ship spin fast and then releasing flares results in:

1. Branch main: A strange, quickly-expanding semicircle of flares
1. This PR: The cloud of flares getting a velocity boost perpendicular (and proportional) to the ship's angular momentum.

Both scenarios are equally explainable (yellow: exit-vectors of flares without rotation. red: angular-momentum-boost experienced by the flare):

1. The back of the ship has many gunbarrels for flares distributed around it. When a flare exits from one gunbarrel, it gets an angular-momentum-boost in a different direction than a flare exiting from a different gunbarrel.
    ![image](https://github.com/user-attachments/assets/2a5eb49e-a65e-4426-9536-453d8fe416be)

2. The back of the ship just has a single gunbarrel for flares, and all flares are shot from that gunbarrel  (but with different angles). Because all flares have the same exit-point, they get exactly the same angular-momentum-boosts.
    ![image](https://github.com/user-attachments/assets/693f519b-5c1f-4822-9797-fcefa62e0ed1)

I argue that 2. is better, for two reasons:
- That behaviour seems less unexpected
- This allows you to pull of cool-looking skilled tricks: By spinning quickly and firing at the right moment, you can direct a volley of flares at the enemies! Try it out, you're more skilled at the game than I am, and I believe you would enjoy pulling off the tricks: `gh pr checkout flare-angular-boost`